### PR TITLE
Add ruleId as parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "rules"
   ],
   "name": "@comparaonline/rule-engine",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Package to allow rule-based configuration of services",
   "private": false,
   "author": {

--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -7,14 +7,14 @@ export abstract class Deserializer<T extends Serializable<Serialized>> {
   protected abstract deserializers: Deserializable<T>[];
   private added: Deserializable<T>[] = [];
 
-  deserialize(obj: Serialized): T {
+  deserialize(obj: Serialized, ruleId?: number): T {
     const deserializer = this.deserializers
       .concat(this.added)
       .find(deserializer => deserializer.canDeserialize(obj));
     if (!deserializer) {
       throw new DeserializationError(obj);
     }
-    return deserializer.deserialize(obj);
+    return deserializer.deserialize(obj, ruleId);
   }
 
   add(deserializable: Deserializable<T>) {

--- a/src/interfaces/deserializable.ts
+++ b/src/interfaces/deserializable.ts
@@ -1,6 +1,6 @@
 import { Serialized } from './serialized';
 
 export interface Deserializable<T> {
-  deserialize(obj: Serialized): T;
+  deserialize(obj: Serialized, ruleId?: number): T;
   canDeserialize(obj: Serialized): boolean;
 }

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -8,7 +8,7 @@ import { Description } from './interfaces/description';
 
 export abstract class Rule<S extends Serialized> extends Conditional
   implements Serializable<S>, Describable {
-  static deserialize(_: Serialized): Rule<Serialized> {
+  static deserialize(_: Serialized, _ruleId?: number): Rule<Serialized> {
     throw new Error('Method not implemented');
   }
 


### PR DESCRIPTION
## Purpose
Add ruleId as an optional parameter to enter the unique identifier of the rule and return it in special cases or exceptions.